### PR TITLE
Add issue and PR templates (closes #4)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Something is broken or incorrect; help us reproduce and fix it
+title: "[bug] "
+---
+
+## Summary
+
+Short description of the bug.
+
+## Expected behavior
+
+## Actual behavior
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- OS:
+- Python version (`python --version`):
+- `qorbital` version or git commit:
+
+## Logs / tracebacks
+
+Paste relevant output inside a fenced code block. Remove secrets before posting.
+
+## Minimal repro (optional)
+
+Smallest script, notebook cell, or CLI invocation that triggers the issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: README & quickstart
+    url: https://github.com/qorbital-lab/qorbital#readme
+    about: Installation and project overview in the repository README

--- a/.github/ISSUE_TEMPLATE/hardware_run.md
+++ b/.github/ISSUE_TEMPLATE/hardware_run.md
@@ -1,0 +1,30 @@
+---
+name: Hardware run
+about: Report or track a run on IonQ simulator or quantum hardware (no secrets)
+title: "[hardware] "
+---
+
+## Security
+
+Do **not** paste API keys, tokens, or credentials. Describe configuration at a high level only.
+
+## Backend
+
+- Backend id (e.g. simulator vs device):
+- Qiskit / provider versions if relevant:
+
+## Experiment
+
+- Molecule / system:
+- Bond length or geometry note:
+- Ansatz / circuit summary (depth, parameters) if applicable:
+
+## Job / result
+
+- Job ID or link (if shareable):
+- Energy or key metrics (optional):
+- What went wrong or what you want validated?
+
+## Reproducibility
+
+Notebook path, script, or PR branch others can use to reproduce (without secrets).

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,37 @@
+---
+name: Task
+about: Scoped deliverable (feature, refactor, or docs) with clear acceptance criteria
+title: "[task] "
+---
+
+## Goal
+
+What problem does this solve or what capability does it add?
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+
+## Scope / components
+
+Check all that apply:
+
+- [ ] `chemistry` (integrals / drivers)
+- [ ] `vqe` / quantum backends
+- [ ] `web` / visualization
+- [ ] `tests` / CI
+- [ ] `docs` / README
+- [ ] Other: <!-- describe -->
+
+## Dependencies
+
+Links to issues or PRs this work depends on (or “none”):
+
+## Estimate
+
+Rough time or complexity (optional):
+
+## Notes
+
+Design notes, links to papers, ADR references, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+What does this PR change and why?
+
+## Related issues
+
+Closes #<!-- issue number -->
+Refs #<!-- issue number -->
+
+## How to test
+
+```bash
+# Example: editable install and tests
+pip install -e ".[dev]"
+pytest
+ruff check src tests
+```
+
+## Checklist
+
+- [ ] Tests pass locally (or CI green)
+- [ ] Docs / README updated if user-facing behavior changed
+- [ ] No secrets, tokens, or private data in commits or description


### PR DESCRIPTION
## Summary

Implements [issue #4](https://github.com/qorbital-lab/qorbital/issues/4):

- **Issue templates:** `task.md`, `bug.md`, `hardware_run.md` under `.github/ISSUE_TEMPLATE/` (YAML front matter for the GitHub chooser).
- **PR template:** `.github/pull_request_template.md`.
- **Chooser config:** `.github/ISSUE_TEMPLATE/config.yml` (`blank_issues_enabled`, README contact link).

Setup guide §6.3 was not in-repo; copy is aligned with qOrbital (chemistry, VQE, web, hardware).

## After merge

Confirm **Issues → New issue** lists the three templates and **Blank issue** (if enabled), and that **new PRs** pre-fill from the PR template.

Closes #4.

Made with [Cursor](https://cursor.com)