### PR TITLE
Add PyVista renderer skeleton for issue #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ density = qorbital.compute_density(result)
 
 # Export mesh for visualization
 mesh = qorbital.to_mesh(density, isovalue=0.02)
+
+# Render in PyVista (notebook)
+from qorbital.viz.pyvista_renderer import show_h2_mock
+
+plotter = show_h2_mock(show=False, jupyter_backend="panel")  # or "ipyvtklink"
+plotter.show()
 ```
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ mesh = qorbital.to_mesh(density, isovalue=0.02)
 # Render in PyVista (notebook)
 from qorbital.viz.pyvista_renderer import show_h2_mock
 
-plotter = show_h2_mock(show=False, jupyter_backend="panel")  # or "ipyvtklink"
+plotter = show_h2_mock(show=False, jupyter_backend="trame")  # or "ipyvtklink"
 plotter.show()
 ```
 

--- a/qorbital/viz/pyvista_renderer.py
+++ b/qorbital/viz/pyvista_renderer.py
@@ -1,0 +1,268 @@
+"""PyVista renderer skeleton for ADR-004 visualization bundles.
+
+Implements:
+- render_isosurface: draw a single isosurface from a mock grid or mesh
+- render_trajectories: draw simple mock trajectories as 3D lines
+- render_combined: draw orbital, trajectories, and atoms from a VisualizationBundle
+
+Designed to satisfy GitHub issue #16 and align with ADR-004 and the Three.js
+viewer skeleton. This module intentionally keeps a small, testable surface
+area and uses mock data until the full chemistry and Bohmian stacks land.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import pyvista as pv
+
+from qorbital.viz.fixtures import grid_mock_bundle, h2_mock_bundle
+from qorbital.viz.schema import DensityGrid, MeshSurface, VisualizationBundle
+
+
+@dataclass
+class MockTrajectory:
+    """Simple in-memory trajectory used before Bohmian engine is available."""
+
+    points: np.ndarray  # shape (N, 3)
+
+
+def _ensure_jupyter_backend(jupyter_backend: str | None) -> None:
+    """Configure PyVista for Jupyter when requested."""
+
+    if jupyter_backend is None:
+        return
+    try:
+        pv.set_jupyter_backend(jupyter_backend)
+    except Exception:  # pragma: no cover - backend availability is environment-specific
+        # If the backend is unavailable, continue with the default one.
+        return
+
+
+def _grid_to_mock_polydata(grid: DensityGrid) -> pv.PolyData:
+    """Convert a tiny DensityGrid into a mock isosurface PolyData.
+
+    This avoids relying on backends that may not be available in all
+    environments while still exercising the rendering path.
+    """
+
+    nx, ny, nz = grid.shape
+    dx, dy, dz = grid.spacing
+    ox, oy, oz = grid.origin
+
+    xs = np.linspace(ox, ox + dx * (nx - 1), nx)
+    ys = np.linspace(oy, oy + dy * (ny - 1), ny)
+    zs = np.linspace(oz, oz + dz * (nz - 1), nz)
+    X, Y, Z = np.meshgrid(xs, ys, zs, indexing="ij")
+
+    r2 = X**2 + Y**2 + Z**2
+    values = np.exp(-r2) - 0.5 * np.exp(-4.0 * r2)
+
+    # Take an isosurface-like band and sample points from it to form a cloud.
+    iso = float(grid.default_isovalue or 0.02)
+    mask = np.logical_and(values > iso * 0.9, values < iso * 1.1)
+    pts = np.stack([X[mask], Y[mask], Z[mask]], axis=1)
+    if pts.size == 0:
+        pts = np.zeros((1, 3), dtype=float)
+
+    poly = pv.PolyData(pts)
+    poly["density"] = values[mask] if values[mask].size > 0 else np.array([iso])
+    return poly
+
+
+def _mesh_surface_to_polydata(surface: MeshSurface) -> pv.PolyData:
+    """Convert a MeshSurface into PyVista PolyData."""
+
+    vertices = np.asarray(surface.vertices, dtype=float)
+    faces = np.asarray(surface.faces, dtype=int)
+
+    if faces.size == 0:
+        return pv.PolyData(vertices)
+
+    # PyVista expects a flat array of [3, i, j, k, 3, ...]
+    n_faces = faces.shape[0]
+    flat_faces = np.hstack(
+        [np.full((n_faces, 1), 3, dtype=int), faces],
+    ).ravel()
+
+    poly = pv.PolyData(vertices, flat_faces)
+    if surface.vertex_scalars is not None:
+        scalars = np.asarray(surface.vertex_scalars, dtype=float)
+        if scalars.shape[0] == vertices.shape[0]:
+            poly["phase"] = scalars
+    return poly
+
+
+def render_isosurface(
+    grid_or_mesh: DensityGrid | MeshSurface,
+    *,
+    isovalue: float | None = None,
+    show: bool = True,
+    jupyter_backend: str | None = "panel",
+) -> pv.Plotter:
+    """Render a single isosurface from a DensityGrid or MeshSurface.
+
+    Returns the Plotter so callers can further customise or embed it in Jupyter.
+    """
+
+    _ensure_jupyter_backend(jupyter_backend)
+    plotter = pv.Plotter()
+
+    if isinstance(grid_or_mesh, DensityGrid):
+        contour = _grid_to_mock_polydata(grid_or_mesh)
+        plotter.add_mesh(
+            contour,
+            cmap="viridis",
+            opacity=0.8,
+            lighting=True,
+        )
+    else:
+        poly = _mesh_surface_to_polydata(grid_or_mesh)
+        scalars = "phase" if "phase" in poly.point_data else None
+        plotter.add_mesh(
+            poly,
+            scalars=scalars,
+            cmap="coolwarm" if scalars else None,
+            opacity=0.85,
+            lighting=True,
+        )
+
+    plotter.set_background("black")
+
+    if show:
+        plotter.show()
+    return plotter
+
+
+def render_trajectories(
+    trajectories: Iterable[MockTrajectory],
+    *,
+    show: bool = True,
+    jupyter_backend: str | None = "panel",
+) -> pv.Plotter:
+    """Render a list of mock trajectories as 3D line objects."""
+
+    _ensure_jupyter_backend(jupyter_backend)
+    plotter = pv.Plotter()
+    for traj in trajectories:
+        if traj.points.size == 0:
+            continue
+        spline = pv.Spline(traj.points, n_points=len(traj.points) * 5)
+        plotter.add_mesh(
+            spline,
+            color="cyan",
+            line_width=2.0,
+            opacity=0.9,
+        )
+    plotter.set_background("black")
+    if show:
+        plotter.show()
+    return plotter
+
+
+def _mock_spiral_trajectories(count: int = 8) -> list[MockTrajectory]:
+    """Generate simple spiral-like trajectories around the origin."""
+
+    trajectories: list[MockTrajectory] = []
+    thetas = np.linspace(0.0, 2.0 * np.pi, count, endpoint=False)
+    for theta0 in thetas:
+        t = np.linspace(0.0, 6.0 * np.pi, 80)
+        r = 0.3 + 0.02 * t
+        x = r * np.cos(t + theta0)
+        y = r * np.sin(t + theta0)
+        z = 0.05 * t - 0.5
+        points = np.stack([x, y, z], axis=1)
+        trajectories.append(MockTrajectory(points=points))
+    return trajectories
+
+
+def _add_atoms_from_bundle(bundle: VisualizationBundle, plotter: pv.Plotter) -> None:
+    """Add simple atom glyphs for the molecule in a bundle."""
+
+    for atom in bundle.molecule.atoms:
+        center = np.asarray(atom.position, dtype=float)
+        radius = 0.3
+        sphere = pv.Sphere(radius=radius, center=center)
+        plotter.add_mesh(
+            sphere,
+            color="white",
+            specular=0.2,
+            smooth_shading=True,
+        )
+
+
+def render_combined(
+    bundle: VisualizationBundle,
+    *,
+    show: bool = True,
+    jupyter_backend: str | None = "panel",
+) -> pv.Plotter:
+    """Render density, trajectories, and atoms from a VisualizationBundle."""
+
+    _ensure_jupyter_backend(jupyter_backend)
+    plotter = pv.Plotter()
+
+    # Density / isosurface
+    if isinstance(bundle.density, DensityGrid):
+        contour = _grid_to_mock_polydata(bundle.density)
+        plotter.add_mesh(
+            contour,
+            cmap="viridis",
+            opacity=0.8,
+            lighting=True,
+        )
+    else:
+        poly = _mesh_surface_to_polydata(bundle.density)
+        scalars = "phase" if "phase" in poly.point_data else None
+        plotter.add_mesh(
+            poly,
+            scalars=scalars,
+            cmap="coolwarm" if scalars else None,
+            opacity=0.85,
+            lighting=True,
+        )
+
+    # Atoms
+    _add_atoms_from_bundle(bundle, plotter)
+
+    # Trajectories (mock for now)
+    for traj in _mock_spiral_trajectories():
+        spline = pv.Spline(traj.points, n_points=len(traj.points) * 4)
+        plotter.add_mesh(
+            spline,
+            color="cyan",
+            line_width=2.0,
+            opacity=0.9,
+        )
+
+    plotter.set_background("black")
+
+    if show:
+        plotter.show()
+    return plotter
+
+
+def show_h2_mock(
+    *,
+    show: bool = True,
+    jupyter_backend: str | None = "panel",
+) -> pv.Plotter:
+    """Convenience helper: render the mock H₂ bundle in a single call."""
+
+    bundle = h2_mock_bundle()
+    return render_combined(bundle, show=show, jupyter_backend=jupyter_backend)
+
+
+def show_grid_mock(
+    *,
+    show: bool = True,
+    jupyter_backend: str | None = "panel",
+) -> pv.Plotter:
+    """Convenience helper: render a tiny grid-based mock bundle."""
+
+    bundle = grid_mock_bundle()
+    return render_combined(bundle, show=show, jupyter_backend=jupyter_backend)
+
+

--- a/qorbital/viz/pyvista_renderer.py
+++ b/qorbital/viz/pyvista_renderer.py
@@ -264,5 +264,3 @@ def show_grid_mock(
 
     bundle = grid_mock_bundle()
     return render_combined(bundle, show=show, jupyter_backend=jupyter_backend)
-
-

--- a/qorbital/viz/pyvista_renderer.py
+++ b/qorbital/viz/pyvista_renderer.py
@@ -12,6 +12,7 @@ area and uses mock data until the full chemistry and Bohmian stacks land.
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import Iterable
 
@@ -36,12 +37,18 @@ def _ensure_jupyter_backend(jupyter_backend: str | None) -> None:
         return
     try:
         pv.set_jupyter_backend(jupyter_backend)
-    except Exception:  # pragma: no cover - backend availability is environment-specific
-        # If the backend is unavailable, continue with the default one.
-        return
+    except (ImportError, ValueError) as err:  # pragma: no cover
+        warnings.warn(
+            f"Could not set jupyter backend to {jupyter_backend!r}: {err}",
+            stacklevel=2,
+        )
 
 
-def _grid_to_mock_polydata(grid: DensityGrid) -> pv.PolyData:
+def _mock_polydata_for_grid_geometry(
+    grid: DensityGrid,
+    *,
+    isovalue: float | None = None,
+) -> pv.PolyData:
     """Convert a tiny DensityGrid into a mock isosurface PolyData.
 
     This avoids relying on backends that may not be available in all
@@ -61,7 +68,7 @@ def _grid_to_mock_polydata(grid: DensityGrid) -> pv.PolyData:
     values = np.exp(-r2) - 0.5 * np.exp(-4.0 * r2)
 
     # Take an isosurface-like band and sample points from it to form a cloud.
-    iso = float(grid.default_isovalue or 0.02)
+    iso = float(isovalue if isovalue is not None else grid.default_isovalue or 0.02)
     mask = np.logical_and(values > iso * 0.9, values < iso * 1.1)
     pts = np.stack([X[mask], Y[mask], Z[mask]], axis=1)
     if pts.size == 0:
@@ -70,6 +77,35 @@ def _grid_to_mock_polydata(grid: DensityGrid) -> pv.PolyData:
     poly = pv.PolyData(pts)
     poly["density"] = values[mask] if values[mask].size > 0 else np.array([iso])
     return poly
+
+
+def _add_density_actor(
+    plotter: pv.Plotter,
+    density: DensityGrid | MeshSurface,
+    *,
+    isovalue: float | None = None,
+) -> None:
+    """Add a density isosurface actor to a plotter."""
+
+    if isinstance(density, DensityGrid):
+        contour = _mock_polydata_for_grid_geometry(density, isovalue=isovalue)
+        plotter.add_mesh(
+            contour,
+            cmap="viridis",
+            opacity=0.8,
+            lighting=True,
+        )
+        return
+
+    poly = _mesh_surface_to_polydata(density)
+    scalars = "phase" if "phase" in poly.point_data else None
+    plotter.add_mesh(
+        poly,
+        scalars=scalars,
+        cmap="coolwarm" if scalars else None,
+        opacity=0.85,
+        lighting=True,
+    )
 
 
 def _mesh_surface_to_polydata(surface: MeshSurface) -> pv.PolyData:
@@ -100,7 +136,7 @@ def render_isosurface(
     *,
     isovalue: float | None = None,
     show: bool = True,
-    jupyter_backend: str | None = "panel",
+    jupyter_backend: str | None = "trame",
 ) -> pv.Plotter:
     """Render a single isosurface from a DensityGrid or MeshSurface.
 
@@ -110,24 +146,7 @@ def render_isosurface(
     _ensure_jupyter_backend(jupyter_backend)
     plotter = pv.Plotter()
 
-    if isinstance(grid_or_mesh, DensityGrid):
-        contour = _grid_to_mock_polydata(grid_or_mesh)
-        plotter.add_mesh(
-            contour,
-            cmap="viridis",
-            opacity=0.8,
-            lighting=True,
-        )
-    else:
-        poly = _mesh_surface_to_polydata(grid_or_mesh)
-        scalars = "phase" if "phase" in poly.point_data else None
-        plotter.add_mesh(
-            poly,
-            scalars=scalars,
-            cmap="coolwarm" if scalars else None,
-            opacity=0.85,
-            lighting=True,
-        )
+    _add_density_actor(plotter, grid_or_mesh, isovalue=isovalue)
 
     plotter.set_background("black")
 
@@ -140,7 +159,7 @@ def render_trajectories(
     trajectories: Iterable[MockTrajectory],
     *,
     show: bool = True,
-    jupyter_backend: str | None = "panel",
+    jupyter_backend: str | None = "trame",
 ) -> pv.Plotter:
     """Render a list of mock trajectories as 3D line objects."""
 
@@ -197,32 +216,14 @@ def render_combined(
     bundle: VisualizationBundle,
     *,
     show: bool = True,
-    jupyter_backend: str | None = "panel",
+    jupyter_backend: str | None = "trame",
 ) -> pv.Plotter:
     """Render density, trajectories, and atoms from a VisualizationBundle."""
 
     _ensure_jupyter_backend(jupyter_backend)
     plotter = pv.Plotter()
 
-    # Density / isosurface
-    if isinstance(bundle.density, DensityGrid):
-        contour = _grid_to_mock_polydata(bundle.density)
-        plotter.add_mesh(
-            contour,
-            cmap="viridis",
-            opacity=0.8,
-            lighting=True,
-        )
-    else:
-        poly = _mesh_surface_to_polydata(bundle.density)
-        scalars = "phase" if "phase" in poly.point_data else None
-        plotter.add_mesh(
-            poly,
-            scalars=scalars,
-            cmap="coolwarm" if scalars else None,
-            opacity=0.85,
-            lighting=True,
-        )
+    _add_density_actor(plotter, bundle.density)
 
     # Atoms
     _add_atoms_from_bundle(bundle, plotter)
@@ -247,7 +248,7 @@ def render_combined(
 def show_h2_mock(
     *,
     show: bool = True,
-    jupyter_backend: str | None = "panel",
+    jupyter_backend: str | None = "trame",
 ) -> pv.Plotter:
     """Convenience helper: render the mock H₂ bundle in a single call."""
 
@@ -258,7 +259,7 @@ def show_h2_mock(
 def show_grid_mock(
     *,
     show: bool = True,
-    jupyter_backend: str | None = "panel",
+    jupyter_backend: str | None = "trame",
 ) -> pv.Plotter:
     """Convenience helper: render a tiny grid-based mock bundle."""
 

--- a/tests/test_viz_pyvista.py
+++ b/tests/test_viz_pyvista.py
@@ -78,4 +78,3 @@ def test_render_combined_from_grid_bundle() -> None:
     plotter = render_combined(bundle, show=False, jupyter_backend=None)
     assert isinstance(plotter, pv.Plotter)
     assert _count_actors(plotter) >= 3
-

--- a/tests/test_viz_pyvista.py
+++ b/tests/test_viz_pyvista.py
@@ -1,0 +1,81 @@
+"""Smoke tests for the PyVista renderer skeleton (issue #16).
+
+These tests avoid opening interactive windows by always using show=False.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import pyvista as pv
+
+from qorbital.viz.fixtures import grid_mock_bundle, h2_mock_bundle
+from qorbital.viz.pyvista_renderer import (
+    MockTrajectory,
+    render_combined,
+    render_isosurface,
+    render_trajectories,
+)
+from qorbital.viz.schema import DensityGrid, MeshSurface
+
+
+def _count_actors(plotter: pv.Plotter) -> int:
+    """Return number of actors in the plotter."""
+
+    return len(list(plotter.renderer.actors.values()))
+
+
+def _mock_trajectories() -> Iterable[MockTrajectory]:
+    import numpy as np
+
+    points = np.array(
+        [
+            [-0.5, 0.0, 0.0],
+            [0.0, 0.5, 0.0],
+            [0.5, 0.0, 0.0],
+        ],
+        dtype=float,
+    )
+    return [MockTrajectory(points=points)]
+
+
+def test_render_isosurface_from_mesh_returns_plotter() -> None:
+    bundle = h2_mock_bundle()
+    assert isinstance(bundle.density, MeshSurface)
+    plotter = render_isosurface(bundle.density, show=False, jupyter_backend=None)
+    assert isinstance(plotter, pv.Plotter)
+    assert _count_actors(plotter) >= 1
+
+
+def test_render_isosurface_from_grid_returns_plotter() -> None:
+    bundle = grid_mock_bundle()
+    assert isinstance(bundle.density, DensityGrid)
+    plotter = render_isosurface(bundle.density, show=False, jupyter_backend=None)
+    assert isinstance(plotter, pv.Plotter)
+    assert _count_actors(plotter) >= 1
+
+
+def test_render_trajectories_returns_plotter() -> None:
+    plotter = render_trajectories(
+        _mock_trajectories(),
+        show=False,
+        jupyter_backend=None,
+    )
+    assert isinstance(plotter, pv.Plotter)
+    assert _count_actors(plotter) >= 1
+
+
+def test_render_combined_from_mesh_bundle() -> None:
+    bundle = h2_mock_bundle()
+    plotter = render_combined(bundle, show=False, jupyter_backend=None)
+    assert isinstance(plotter, pv.Plotter)
+    # Surface + atoms + trajectories should produce multiple actors.
+    assert _count_actors(plotter) >= 3
+
+
+def test_render_combined_from_grid_bundle() -> None:
+    bundle = grid_mock_bundle()
+    plotter = render_combined(bundle, show=False, jupyter_backend=None)
+    assert isinstance(plotter, pv.Plotter)
+    assert _count_actors(plotter) >= 3
+


### PR DESCRIPTION
## Summary
- Add `qorbital.viz.pyvista_renderer` with skeleton rendering APIs for `render_isosurface`, `render_trajectories`, and `render_combined`.
- Support ADR-004 bundle types (`MeshSurface` and `DensityGrid`) with mock-friendly rendering paths for Jupyter demos.
- Add `show_h2_mock()` / `show_grid_mock()` helpers and atom glyph + trajectory overlays for combined views.
- Add smoke tests in `tests/test_viz_pyvista.py` and README usage example.

Closes #16

## Test plan
- [x] `ruff check qorbital tests`
- [x] `pytest tests/test_viz_pyvista.py -q`
- [ ] Manual notebook check: `from qorbital.viz.pyvista_renderer import show_h2_mock` then `show_h2_mock(show=False).show()`


Made with [Cursor](https://cursor.com)